### PR TITLE
Fix for admin settings

### DIFF
--- a/app/assets/js/admin/controllers.js
+++ b/app/assets/js/admin/controllers.js
@@ -229,7 +229,7 @@ angular.module('hadronAdmin.controllers', [
         }
 
         var data = {
-          admin: settings.admin
+          adminUser: settings.adminUser
         };
         return $http.put('api/settings', data).success(function(data) {
           notifyUser({text: "Settings successfully saved", type:'success'});


### PR DESCRIPTION
Setting the admin username/password isn't working as `data` in `adminSettingsCtrl` controller was referencing `admin: settings.admin` rather than`adminUser: settings.adminUser`
