### PR TITLE
Ability to add headline image to posts

### DIFF
--- a/app/data/models/Post.js
+++ b/app/data/models/Post.js
@@ -38,7 +38,8 @@ var Post = minimodel.Model.extend({
     default: 'markdown'
   },
   lead: String,
-  friendlyUrl: String
+  friendlyUrl: String,
+  headlineImage: String
 });
 
 Post.prototype.getRenderedContent = function() {

--- a/app/views/clientTemplates/admin/savePost.jade
+++ b/app/views/clientTemplates/admin/savePost.jade
@@ -3,6 +3,10 @@ form(role="form", name="savePostForm", novalidate)
     label.control-label(for="title") Title
     input.form-control(name="title", ng-model="post.title", placeholder="Enter the post title", required)
     span.control-label(ng-show="hasError('savePostForm.title.required')") Required!
+
+  .form-group(ng-class="{'has-error': hasError('savePostForm.headlineImage')}")
+      label.control-label(for="headlineImage") Headline Image
+      input.form-control(name="headlineImage", ng-model="post.headlineImage", placeholder="Enter URL for headline image")
   
   .form-group(ng-class="{'has-error': hasError('savePostForm.friendlyUrl')}")
     label.control-label(for="friendlyUrl") Friendly Url

--- a/app/views/index.jade
+++ b/app/views/index.jade
@@ -8,7 +8,10 @@ block main
   .article-list
     each post in posts
       article
-        h2
+        if post.headlineImage
+          h2
+            img.headline-image(src="#{post.headlineImage}")= post.headlineImage
+        h2 
           a(href="/#{post.friendlyUrl}")= post.title
         .summary= post.lead
         div.subheading

--- a/app/views/posts/view.jade
+++ b/app/views/posts/view.jade
@@ -34,12 +34,12 @@ block main
     
     .lead= post.lead
     .article-content!= post.getRenderedContent()
-  // VIEW-CONTRIBUTION-START[post-view-article-footer]
-  // VIEW-CONTRIBUTION-END[post-view-article-footer]
+  //INJECT:viewContributions:post-view-article-footer
+  //END INJECT
 
 block footer
-  // VIEW-CONTRIBUTION-START[post-view-footer]
-  // VIEW-CONTRIBUTION-END[post-view-footer]
+  //INJECT:viewContributions:post-view-footer
+  //END INJECT
   if(settings.social.twitter.showShareButton)
     script.
       //Twitter share button

--- a/app/views/posts/view.jade
+++ b/app/views/posts/view.jade
@@ -6,6 +6,9 @@ block head
 
 block main
   article
+    if post.headlineImage
+      h1
+        img.headline-image(src="#{post.headlineImage}")= post.headlineImage
     h1
       a(href="/#{post.friendlyUrl}")= post.title
     .subheading
@@ -31,12 +34,12 @@ block main
     
     .lead= post.lead
     .article-content!= post.getRenderedContent()
-  //INJECT:viewContributions:post-view-article-footer
-  //END INJECT
+  // VIEW-CONTRIBUTION-START[post-view-article-footer]
+  // VIEW-CONTRIBUTION-END[post-view-article-footer]
 
 block footer
-  //INJECT:viewContributions:post-view-footer
-  //END INJECT
+  // VIEW-CONTRIBUTION-START[post-view-footer]
+  // VIEW-CONTRIBUTION-END[post-view-footer]
   if(settings.social.twitter.showShareButton)
     script.
       //Twitter share button


### PR DESCRIPTION
I needed to be able to add headline images to a post, so I extended Hadron a bit. Only accepts image URLs for now. Might look into upload functionality at a later stage. I thought it might be useful for others.

![image](https://cloud.githubusercontent.com/assets/4135045/2748951/2eb5bdbe-c7e3-11e3-8655-983e2dbdb35f.png)

![image](https://cloud.githubusercontent.com/assets/4135045/2748956/3e8acdba-c7e3-11e3-97f9-893e9c71941b.png)

Related [hadron-theme-nodus PR](https://github.com/hadronjs/hadron-theme-nodus/pull/1) to ensure image doesn't exceed article width.
